### PR TITLE
Fix San Jose Round1 to ERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Finally all in one place; no more feeling out of the loop when someone refers to
 |**DBF**|Danbury Fair|Danbury|CT|
 |**DBK**|Deerbrook Mall|Humble|TX|
 |**DFM**|Deptford Mall|Deptford|NJ|
-|**ESC**|Eastridge Shopping Center|San Jose|CA|
+|**ERM**|Eastridge Mall|San Jose|CA|
 |**EXM**|Exton Square Mall|Exton|PA|
 |**FDP**|Fashion District Philadelphia|Philadelphia|PA|
 |**FFC**|Fairfield Commons|Beavercreek|OH|
@@ -85,7 +85,7 @@ Finally all in one place; no more feeling out of the loop when someone refers to
 |**RVM**|Westfield Galleria at Roseville|Roseville|CA|
 |**NRM**|Northridge Mall|Salinas|CA|
 |**STG**|Stonestown Galleria|San Francisco|CA|
-|**ESC**|Eastridge Shopping Center|San Jose|CA|
+|**ERM**|Eastridge Mall|San Jose|CA|
 |**MPM**|Main Place Mall|Santa Ana|CA|
 |**TMP**|Promenade Temecula|Temecula|CA|
 |**SWP**|Southwest Plaza|Littleton|CO|

--- a/r1index.csv
+++ b/r1index.csv
@@ -9,7 +9,7 @@ CRG,Galleria at Crystal Run,Middletown,NY
 DBF,Danbury Fair,Danbury,CT
 DBK,Deerbrook Mall,Humble,TX
 DFM,Deptford Mall,Deptford,NJ
-ESC,Eastridge Shopping Center,San Jose,CA
+ERM,Eastridge Mall,San Jose,CA
 EXM,Exton Square Mall,Exton,PA
 FDP,Fashion District Philadelphia,Philadelphia,PA
 FFC,Fairfield Commons,Beavercreek,OH


### PR DESCRIPTION
San Jose Eastridge Mall is referred to as ERM, I have never heard anyone call it ESC and the Round1 source link you mentioned did not exist for it (https://partytime.round1usa.com/reservation/index/ESC)

Source: Have been to R1 ERM, in discord server for NorCal, talked to many cali locals and asked if anyone had heard it called ESC.